### PR TITLE
Update Hunter_Hydrawise_System

### DIFF
--- a/Hunter_Hydrawise_System
+++ b/Hunter_Hydrawise_System
@@ -77,7 +77,7 @@ def refresh()
 def updated()
 {
     logDebug("Hunter Hydrawise System: updated()")
-    configure()
+   
 }
 
 def uninstalled()


### PR DESCRIPTION
I don't know hubitat's developer API , I tried to find some documentation about it, but didn't find any, will definitely appreciate if you can point me to some. But what I see that every time I click safe preferences (for instance to toggle debuging loging on/off) update() function is call, which in turn calls configure() that try to add/delete child devices. I don't think it's desired behavior. I think update() shouldn't really do anything for this driver. But if the user would like to add/refresh all device, the user should just clock on Configure command that will trigger configure() function call.