### PR TITLE
Update Hunter_Hydrawise_Controller

### DIFF
--- a/Hunter_Hydrawise_Controller
+++ b/Hunter_Hydrawise_Controller
@@ -64,8 +64,6 @@ def logDebug(msg)
 def updated()
 {
     logDebug("Hunter Hydrawise Controller: updated()")
-
-    configure()
 }
 
 def configure()


### PR DESCRIPTION
Same the controller. No need to cal configure when update() is triggered. configure can be called explicitely by clocking on Configure action . Otherwise, child devices are recreated every time new preferences are saved.